### PR TITLE
Changed timepicker tbd behavior

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -41,6 +41,9 @@ module.exports = function(config) {
       'sport-ng.js',
       './!(lib|node_modules|bower_components)/**/!(*-test).js',
 
+      // Translation files...
+      { pattern: 'locales/**/*.json', included: false, served: true },
+
       // Test files
       './!(lib|node_modules|bower_components)/**/*-test.js'
     ],

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -39,6 +39,7 @@ module.exports = function(config) {
 
       // App code
       'sport-ng.js',
+      'sport-ng-karma.js',
       './!(lib|node_modules|bower_components)/**/!(*-test).js',
 
       // Translation files...

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -1,0 +1,19 @@
+
+{
+  "Cancel"                  : "Cancel",
+  "confirm_delete"          : "Deleting &#8220;__name__&#8221; cannot be undone.",
+  "confirm_delete_header"   : "Delete __type__",
+
+  "TIME_REMAINING" : {
+    "minute"                : "__count__ minute",
+    "minute_plural"         : "__count__ minutes",
+    "second"                : "__count__ second",
+    "second_plural"         : "__count__ seconds",
+    "remaining"             : "remaining...",
+    "remaining_placeholder" : "Calculating time remaining..."
+  },
+
+  "time_tbd"                : "TBD",
+  "type_to_delete"          : "Type the __type__ name to delete.",
+  "Yes_Delete_It"           : "Yes, Delete It!"
+}

--- a/sport-ng-karma.js
+++ b/sport-ng-karma.js
@@ -1,0 +1,31 @@
+angular.module('sport.ng')
+  .config(function (i18ngProvider) {
+
+    function addKarmaBase(url) {
+      if (typeof window.__karma__ !== 'undefined') return '/base' + url
+      return url
+    }
+
+    i18ngProvider.init({
+      // Yes, this tells i18next to block.
+      //
+      // i18ng calls $digest() to update template translations after init.
+      // Unfortunately, we don't have a way to update translations that
+      // occured anywhere else.  (Such as manually calling t() in a
+      // controller or model.)
+      //
+      // The backbone side of the app calls it's own i18next init, and
+      // then creates a global promise that's resolved once the init
+      // finishes.  The angular backbone-controller then defers all
+      // page loads through that promise.
+      //
+      // Instead of adding that sort of code to then angular side, I'm
+      // just going to have it block.  It only affects initial app load.
+      getAsync: false,
+      lng: 'en',
+      useCookie: false,
+      useLocalStorage: false,
+      fallbackLng: 'en',
+      resGetPath: addKarmaBase('/locales/__lng__/__ns__.json')
+    })
+  })

--- a/sport-ng.js
+++ b/sport-ng.js
@@ -6,35 +6,3 @@ angular.module('sport.ng', [
   'i18ng',
   'restangular'
 ])
-
-angular.module('sport.ng')
-  .config(function (i18ngProvider) {
-
-    function addKarmaBase(url) {
-      if (typeof window.__karma__ !== 'undefined') return '/base' + url
-      return url
-    }
-
-    i18ngProvider.init({
-      // Yes, this tells i18next to block.
-      //
-      // i18ng calls $digest() to update template translations after init.
-      // Unfortunately, we don't have a way to update translations that
-      // occured anywhere else.  (Such as manually calling t() in a
-      // controller or model.)
-      //
-      // The backbone side of the app calls it's own i18next init, and
-      // then creates a global promise that's resolved once the init
-      // finishes.  The angular backbone-controller then defers all
-      // page loads through that promise.
-      //
-      // Instead of adding that sort of code to then angular side, I'm
-      // just going to have it block.  It only affects initial app load.
-      getAsync: false,
-      lng: 'en',
-      useCookie: false,
-      useLocalStorage: false,
-      fallbackLng: 'en',
-      resGetPath: addKarmaBase('/locales/__lng__/__ns__.json')
-    })
-  })

--- a/sport-ng.js
+++ b/sport-ng.js
@@ -6,3 +6,35 @@ angular.module('sport.ng', [
   'i18ng',
   'restangular'
 ])
+
+angular.module('sport.ng')
+  .config(function (i18ngProvider) {
+
+    function addKarmaBase(url) {
+      if (typeof window.__karma__ !== 'undefined') return '/base' + url
+      return url
+    }
+
+    i18ngProvider.init({
+      // Yes, this tells i18next to block.
+      //
+      // i18ng calls $digest() to update template translations after init.
+      // Unfortunately, we don't have a way to update translations that
+      // occured anywhere else.  (Such as manually calling t() in a
+      // controller or model.)
+      //
+      // The backbone side of the app calls it's own i18next init, and
+      // then creates a global promise that's resolved once the init
+      // finishes.  The angular backbone-controller then defers all
+      // page loads through that promise.
+      //
+      // Instead of adding that sort of code to then angular side, I'm
+      // just going to have it block.  It only affects initial app load.
+      getAsync: false,
+      lng: 'en',
+      useCookie: false,
+      useLocalStorage: false,
+      fallbackLng: 'en',
+      resGetPath: addKarmaBase('/locales/__lng__/__ns__.json')
+    })
+  })

--- a/timepicker/timepickerDirective-test.js
+++ b/timepicker/timepickerDirective-test.js
@@ -29,6 +29,47 @@ describe('TimepickerDirective', function () {
     compileDirective()
   })
 
+  describe('#placeholders TBD allowed', function() {
+
+    describe('no placeholder', function() {
+      beforeEach(function(){
+        compileDirective('<input timepicker ng-model="timeval" allowtbd="true" />')
+      })
+
+      it('should replace lack of placeholder with "TBD"', function() {
+        // expected until translations are enabled in sport-ng karma
+        // should be 'TBD' when used in application
+        expect(elm.attr('placeholder')).toEqual('time_tbd')
+      })
+
+    })
+
+    describe('empty placeholder', function() {
+      beforeEach(function(){
+        compileDirective('<input timepicker ng-model="timeval" allowtbd="true" placeholder="" />')
+      })
+
+      it('should allow placeholder to be an empty string', function() {
+        expect(elm.attr('placeholder')).toEqual('')
+      })
+
+    })
+
+    describe('different placeholder', function() {
+      beforeEach(function(){
+        compileDirective('<input timepicker ng-model="timeval" allowtbd="true" placeholder="asdfk" />')
+      })
+
+      it('should not override specificed placeholder', function() {
+        expect(elm.attr('placeholder')).toEqual('asdfk')
+      })
+
+    })
+
+
+
+  })
+
   describe('#print default (12hour) format', function () {
 
     it('should display 00:00 as 12:00 am', function() {

--- a/timepicker/timepickerDirective-test.js
+++ b/timepicker/timepickerDirective-test.js
@@ -37,9 +37,7 @@ describe('TimepickerDirective', function () {
       })
 
       it('should replace lack of placeholder with "TBD"', function() {
-        // expected until translations are enabled in sport-ng karma
-        // should be 'TBD' when used in application
-        expect(elm.attr('placeholder')).toEqual('time_tbd')
+        expect(elm.attr('placeholder')).toEqual('TBD')
       })
 
     })

--- a/timepicker/timepickerDirective-test.js
+++ b/timepicker/timepickerDirective-test.js
@@ -76,11 +76,11 @@ describe('TimepickerDirective', function () {
 
   describe('#print TBD allowed', function () {
 
-    it('should display \'\' as "TBD" when TBD is allowed', function() {
+    it('should display "" as "" when TBD is allowed', function() {
       $parentScope.timeval = ''
       $parentScope.tbd = true
       compileDirective('<input timepicker ng-model="timeval" allowtbd="tbd" />')
-      expect(elm.val()).toEqual('TBD')
+      expect(elm.val()).toEqual('')
     })
 
   })
@@ -152,15 +152,15 @@ describe('TimepickerDirective', function () {
       compileDirective('<input timepicker ng-model="timeval" allowtbd="tbd" />')
     })
 
-    it('should transform "tbd" to "TBD" when TBD is allowed', function() {
+    it('should transform "tbd" to "" when TBD is allowed', function() {
       changeInput(elm, 'tbd')
-      expect(elm.val()).toEqual('TBD')
+      expect(elm.val()).toEqual('')
       expect($parentScope.timeval).toEqual('')
     })
 
-    it('should transform an empty string to "TBD" when TBD is allowed', function() {
-      changeInput(elm, '')
-      expect(elm.val()).toEqual('TBD')
+    it('should transform an "TBD" to "" when TBD is allowed', function() {
+      changeInput(elm, 'TBD')
+      expect(elm.val()).toEqual('')
       expect($parentScope.timeval).toEqual('')
     })
 

--- a/timepicker/timepickerDirective.js
+++ b/timepicker/timepickerDirective.js
@@ -18,7 +18,8 @@ saveFormat attribute:
   must be a string that is a valid moment format
 
 allowtbd attribute:
-  The allowtbd attribute is optional and denotes whether a blank time will be converted to 'TBD' or rejected
+  The allowtbd attribute is optional and denotes whether a blank time will be converted to '' or rejected
+  intenteded to be used with placeholder="TBD"
   set to `false` by default
   must be a boolean
 
@@ -56,7 +57,6 @@ function print(time, format, allowTBD) {
     return format(time, allowTBD)
   }
   if (!time.isValid()){
-    if (allowTBD) return 'TBD'
     return ''
   }
   return time.format(format)

--- a/timepicker/timepickerDirective.js
+++ b/timepicker/timepickerDirective.js
@@ -70,7 +70,7 @@ var defaults = {
 }
 
 angular.module('sport.ng')
-  .directive('timepicker', function(_) {
+  .directive('timepicker', function(_, i18ng) {
     return {
       restrict: 'A',
       require: 'ngModel',
@@ -84,6 +84,8 @@ angular.module('sport.ng')
 
         var opts = {}
         _.extend(opts, _.defaults(_.pick(scope, ['allowtbd', 'saveFormat', 'print', 'parse']), defaults))
+
+        if (opts.allowtbd && !('placeholder' in attrs)) element.attr('placeholder', i18ng.t('time_tbd'))
 
         function fromModel(modelValue) {
           if (modelValue == '24:00') modelValue = '00:00'

--- a/timepicker/timepickerDirective.js
+++ b/timepicker/timepickerDirective.js
@@ -18,8 +18,7 @@ saveFormat attribute:
   must be a string that is a valid moment format
 
 allowtbd attribute:
-  The allowtbd attribute is optional and denotes whether a blank time will be converted to '' or rejected
-  intenteded to be used with placeholder="TBD"
+  The allowtbd attribute is optional and denotes whether a blank time will be rejected
   set to `false` by default
   must be a boolean
 


### PR DESCRIPTION
Description and Impact
----------------------
Instead of saving a 'TBD' time as an empty string and displaying it as `TBD`, unspecified times will now be both saved as empty strings and displayed at empty strings.
When the developer allows a time to be unspecified, the timepicker will automatically add a `TBD` placeholder to the element, to be shown when the time is unspecified, unless the developer adds an alternative placeholder.

Deploy Plan
-----------

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
* [Jira issue TOURNEY-1597](https://sportngin.atlassian.net/browse/TOURNEY-1597)

QA Plan
-------

#### Happy Path Scenarios

- [x] make sure tests pass (you'll have to do this locally)

##### `<input timepicker allowtbd="true" />`
- [x] when the user enters `TBD`, `tbd`, or an empty string, the form field should be set to an empty string on blur
- [x] when the user enters above things, the form field should be saved as an empty string.
- [x] the placeholder should be set to `TBD`

##### `<input timepicker allowtbd="true" placeholder="" />` or  `<input timepicker allowtbd="true" placeholder="anything" />`
- [x] when the user enters `TBD`, `tbd`, or an empty string, the form field should be set to an empty string on blur
- [x] when the user enters above things, the form field should be saved as an empty string.
- [x] the placeholder should not be overwritten

#### Additional Scenarios (Edge Case, Negative, etc.)

#### Regression Scenarios
