### PR TITLE
Updated sport-ng with Jesse's changes from sport admin

### DIFF
--- a/progressBar/progressBarDirective.js
+++ b/progressBar/progressBarDirective.js
@@ -57,8 +57,8 @@ angular.module('sport.ng')
         }
 
         scope._completed = function() {
-          total = total || 1
-          completed = total
+          scope.total = scope.total || 1
+          scope.completed = scope.total
         }
 
         scope.$watch('promise', function(promise) {


### PR DESCRIPTION
sport-ng and sport admin have different versions of the progress bar. This PR should fix them.

https://github.com/sportngin/sport-ng/commit/8e9be62f1a675b85ac78d7c290ab08f3eaaca2f0 ?