### PR TITLE
Remove All The Useless Things

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -18,7 +18,7 @@ module.exports = function(grunt) {
 
   grunt.registerTask('test',    ['karma'])
   grunt.registerTask('ci',      ['test'])
-  grunt.registerTask('default', ['karma'])
+  grunt.registerTask('default', ['test'])
 
   // load the grunt task plugins
   grunt.loadNpmTasks('grunt-karma')

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -7,27 +7,6 @@ module.exports = function(grunt) {
   // Project configuration.
   grunt.initConfig({
 
-    "bower-install": {
-
-      target: {
-
-        // Point to the files that should be updated when
-        // you run `grunt bower-install`
-        src: [
-
-        ],
-
-        // Optional:
-        // ---------
-        cwd: '',
-        dependencies: false,
-        devDependencies: true,
-        exclude: [],
-        fileTypes: {},
-        ignorePath: ''
-      }
-    },
-
     karma: {
       unit: {
         configFile: 'karma.conf.js',
@@ -37,16 +16,11 @@ module.exports = function(grunt) {
 
   })
 
-  // Default task.
-  // put require before handlebars because require wipes the dir
-
-  grunt.registerTask('setup',   ['npm-install', 'bower-install'])
   grunt.registerTask('test',    ['karma'])
   grunt.registerTask('ci',      ['test'])
+  grunt.registerTask('default', ['karma'])
 
   // load the grunt task plugins
-  grunt.loadNpmTasks('grunt-bower-install')
-  grunt.loadNpmTasks('grunt-npm-install');
   grunt.loadNpmTasks('grunt-karma')
 
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 Contribute
-===============
+==========
 
 1. **Install dependencies**
 
@@ -11,10 +11,6 @@ Contribute
 
    ```bower install```
 
-2. **Project setup:**
-
-    ```grunt setup```
-
 2. **Run the unit tests:**
 
     ```grunt test``` - to run the all tests once in phantom js.
@@ -24,7 +20,7 @@ Contribute
 
 
 Install via Bower
-==============
+=================
 
 1. Run the following command in your project's root folder (where bower.json lives):
 

--- a/package.json
+++ b/package.json
@@ -6,8 +6,6 @@
   "dependencies": {},
   "devDependencies": {
     "grunt": "0.4.1",
-    "grunt-bower-install": "~0.8.0",
-    "grunt-npm-install": "~0.1.0",
     "grunt-karma": "~0.8.0",
     "karma": "~0.12.0",
     "karma-coffee-preprocessor": "~0.1.3",


### PR DESCRIPTION
I was going to update sport-ng from `grunt-bower-install` to `grunt-wiredep`, but it looks like it isn't even being used. I have burned it and scraped it from the documentation.