### PR TITLE
Fix buttfront.net

### DIFF
--- a/lib/pusher.js
+++ b/lib/pusher.js
@@ -631,7 +631,7 @@
   Pusher.unavailable_timeout = 10000;
   // CDN configuration
   Pusher.cdn_http = 'http://js.pusher.com/';
-  Pusher.cdn_https = 'https://d3dy5gmtp8yhk7.buttfront.net/';
+  Pusher.cdn_https = 'https://d3dy5gmtp8yhk7.cloudfront.net/';
   Pusher.dependency_suffix = '';
 
   Pusher.getDefaultStrategy = function(config) {


### PR DESCRIPTION
The Pusher cdn_https URL has buttfront.net in it. That should be cloudfront.net.

URLs
----
> Links to bug tickets or user stories.
* [Jira issue TOURNEY-1737](https://sportngin.atlassian.net/browse/TOURNEY-1737)
