### PR TITLE
Datepicker Refactor

### DIFF
--- a/datepicker/datepicker.html
+++ b/datepicker/datepicker.html
@@ -1,1 +1,0 @@
-<input type="text" ng-focus="show()" ng-click="show()" ng-blur="blur()" class="datepicker" />

--- a/datepicker/datepicker.html
+++ b/datepicker/datepicker.html
@@ -1,1 +1,1 @@
-<input type="text" ng-focus="show()" ng-click="show()" ng-blur="tryHide()" ng-model="displayDate" class="datepicker" />
+<input type="text" ng-focus="show()" ng-click="show()" ng-blur="blur()" class="datepicker" />

--- a/datepicker/datepickerDirective.js
+++ b/datepicker/datepickerDirective.js
@@ -80,16 +80,12 @@ angular.module('sport.ng')
             DatepickerService.show(element, ngModel.$modelValue, setDate)
         }
 
-        function tryHide() {
-          DatepickerService.tryHide()
-        }
-
         ngModel.$formatters.push(displayFormat)
         ngModel.$parsers.push(modelFormat)
 
         element.on('blur', function() {
-          element.val(displayFormat(ngModel.$modelValue))
-          scope.$apply(tryHide)
+          setDate(ngModel.$modelValue)
+          scope.$apply(setDate(ngModel.$modelValue))
         })
         element.on('focus', function() {
           scope.$apply(show)

--- a/datepicker/datepickerDirective.js
+++ b/datepicker/datepickerDirective.js
@@ -11,7 +11,7 @@ Usage:
   The datepicker directive should be used whereever a datepicker input
   should be displayed:
 
-    <input datepicker type="text" ng-model="ctrl.eventDate" />
+    <datepicker ng-model="ctrl.eventDate"></datepicker>
 
 ng-model attribute:
   ng-model is required and will store dates in YYYY-MM-DD format
@@ -63,42 +63,32 @@ function calendarDays(year, month) {
 }
 
 angular.module('sport.ng')
-  .directive('datepicker', function(DatepickerService, _, $parse, $timeout) {
+  .directive('datepicker', function(DatepickerService, _, $timeout) {
     return {
-      restrict: 'A',
+      restrict: 'E',
+      replace: true,
+      scope: {},
       require: 'ngModel',
+      templateUrl: '/bower_components/sport-ng/datepicker/datepicker.html',
       link: function(scope, element, attrs, ngModel) {
-        element.addClass('datepicker')
-
-        // using $parse to set ngModel.$modelValue
-        var modelSetter = $parse(attrs['ngModel']).assign
 
         function setDate(date) {
-          modelSetter(scope, date)
+          ngModel.$setViewValue(displayFormat(date))
+          ngModel.$render()
         }
 
-        function show() {
+        scope.show = function() {
           if (!refocusing)
             DatepickerService.show(element, ngModel.$modelValue, setDate)
         }
 
-        function tryHide() {
+        scope.blur = function() {
+          setDate(ngModel.$modelValue)
           DatepickerService.tryHide()
         }
 
         ngModel.$formatters.push(displayFormat)
         ngModel.$parsers.push(modelFormat)
-
-        element.on('blur', function() {
-          element.val(displayFormat(ngModel.$modelValue))
-          scope.$apply(tryHide)
-        })
-        element.on('focus', function() {
-          scope.$apply(show)
-        })
-        element.on('click', function() {
-          scope.$apply(show)
-        })
 
       }
     }
@@ -170,12 +160,12 @@ angular.module('sport.ng')
         }
 
         scope.nextMonth = function(year, month) {
-          var next = moment({'year': year, 'month': month + 1})
+          var next = moment({'year': year, 'month': month}).add(1, 'months')
           setScope(next.year(), next.month())
         }
 
         scope.previousMonth = function(year, month) {
-          var prev = moment({'year': year, 'month': month - 1})
+          var prev = moment({'year': year, 'month': month}).subtract(1, 'months')
           setScope(prev.year(), prev.month())
         }
 

--- a/datepicker/datepickerDirective.js
+++ b/datepicker/datepickerDirective.js
@@ -78,9 +78,9 @@ angular.module('sport.ng')
           var formats = ['MMMM D YYYY', 'MM DD YYYY']
           var date = moment(date, formats)
           // angular validation. improve when we update to >=1.3.0
-          if (date.isValid()) ngModel.$setValidity('date', true)
-          else ngModel.$setValidity('date', false)
-          return date.isValid() ? date.format('YYYY-MM-DD') : undefined
+          var valid = date.isValid()
+          ngModel.$setValidity('date', valid)
+          return valid ? date.format('YYYY-MM-DD') : undefined
         }
 
         ngModel.$formatters.push(displayFormat)
@@ -88,7 +88,7 @@ angular.module('sport.ng')
 
         element.on('blur', function() {
           setDate(ngModel.$modelValue)
-          scope.$apply(DatepickerService.tryHide())
+          scope.$apply(DatepickerService.tryHide)
         })
         element.on('focus', function() {
           scope.$apply(show)

--- a/datepicker/datepickerDirective.js
+++ b/datepicker/datepickerDirective.js
@@ -24,16 +24,6 @@ ng-model attribute:
 // state of the state
 var refocusing = false
 
-function displayFormat(date) {
-  return (moment(date).isValid() && !!date) ? moment(date).format('MMMM D YYYY'): ''
-}
-
-function modelFormat(date) {
-  var formats = ['MMMM D YYYY', 'MM DD YYYY']
-  var date = moment(date, formats)
-  return date.isValid() ? date.format('YYYY-MM-DD') : null
-}
-
 // Returns an array of arrays for the given month.
 // Each array represents a week and contains seven days.
 function calendarDays(year, month) {
@@ -80,12 +70,25 @@ angular.module('sport.ng')
             DatepickerService.show(element, ngModel.$modelValue, setDate)
         }
 
+        function displayFormat(date) {
+          return (moment(date).isValid() && !!date) ? moment(date).format('MMMM D YYYY'): ''
+        }
+
+        function modelFormat(date) {
+          var formats = ['MMMM D YYYY', 'MM DD YYYY']
+          var date = moment(date, formats)
+          // angular validation. improve when we update to >=1.3.0
+          if (date.isValid()) ngModel.$setValidity('date', true)
+          else ngModel.$setValidity('date', false)
+          return date.isValid() ? date.format('YYYY-MM-DD') : undefined
+        }
+
         ngModel.$formatters.push(displayFormat)
         ngModel.$parsers.push(modelFormat)
 
         element.on('blur', function() {
           setDate(ngModel.$modelValue)
-          scope.$apply(setDate(ngModel.$modelValue))
+          scope.$apply(DatepickerService.tryHide())
         })
         element.on('focus', function() {
           scope.$apply(show)

--- a/datepicker/datepickerDirective.js
+++ b/datepicker/datepickerDirective.js
@@ -11,7 +11,7 @@ Usage:
   The datepicker directive should be used whereever a datepicker input
   should be displayed:
 
-    <datepicker ng-model="ctrl.eventDate"></datepicker>
+    <input datepicker type="text" ng-model="ctrl.eventDate" />
 
 ng-model attribute:
   ng-model is required and will store dates in YYYY-MM-DD format
@@ -65,30 +65,38 @@ function calendarDays(year, month) {
 angular.module('sport.ng')
   .directive('datepicker', function(DatepickerService, _, $timeout) {
     return {
-      restrict: 'E',
-      replace: true,
-      scope: {},
+      restrict: 'A',
       require: 'ngModel',
-      templateUrl: '/bower_components/sport-ng/datepicker/datepicker.html',
       link: function(scope, element, attrs, ngModel) {
+        element.addClass('datepicker')
 
         function setDate(date) {
           ngModel.$setViewValue(displayFormat(date))
           ngModel.$render()
         }
 
-        scope.show = function() {
+        function show() {
           if (!refocusing)
             DatepickerService.show(element, ngModel.$modelValue, setDate)
         }
 
-        scope.blur = function() {
-          setDate(ngModel.$modelValue)
+        function tryHide() {
           DatepickerService.tryHide()
         }
 
         ngModel.$formatters.push(displayFormat)
         ngModel.$parsers.push(modelFormat)
+
+        element.on('blur', function() {
+          element.val(displayFormat(ngModel.$modelValue))
+          scope.$apply(tryHide)
+        })
+        element.on('focus', function() {
+          scope.$apply(show)
+        })
+        element.on('click', function() {
+          scope.$apply(show)
+        })
 
       }
     }
@@ -160,12 +168,12 @@ angular.module('sport.ng')
         }
 
         scope.nextMonth = function(year, month) {
-          var next = moment({'year': year, 'month': month}).add(1, 'months')
+          var next = moment({'year': year, 'month': month}).add(1, 'month')
           setScope(next.year(), next.month())
         }
 
         scope.previousMonth = function(year, month) {
-          var prev = moment({'year': year, 'month': month}).subtract(1, 'months')
+          var prev = moment({'year': year, 'month': month}).subtract(1, 'month')
           setScope(prev.year(), prev.month())
         }
 


### PR DESCRIPTION
The old datepicker was overly complex and did not meet our needs. The following updates make the datepicker easier to use and maintain:
- Using moment instead of writing our own functions
- Using ng-model on an input instead of templating
- Saving date as a yyyy-mm-dd string instead of a date object
- Allowing null dates to be saved

For QA plan and more notes, see pull 1830 in the private repo