### PR TITLE
Timepicker Refactor

### DIFF
--- a/timepicker/timepickerDirective-test.js
+++ b/timepicker/timepickerDirective-test.js
@@ -231,7 +231,7 @@ describe('TimepickerDirective', function () {
 
   })
 
-  describe('#parse custom', function(){
+  describe('#parse custom function', function(){
     beforeEach(function(){
       $parentScope.timeval = '23:00'
       $parentScope.format = function() { return moment('9:00am', 'h:mma') }
@@ -242,6 +242,36 @@ describe('TimepickerDirective', function () {
       changeInput(elm, '10:00 pm')
       expect(elm.val()).toEqual('9:00 am')
       expect($parentScope.timeval).toEqual('09:00')
+    })
+
+  })
+
+  describe('#parse custom format string', function(){
+    beforeEach(function(){
+      $parentScope.timeval = '23:00'
+      $parentScope.format = 'h:mm:ss'
+      compileDirective('<input timepicker ng-model="timeval" parse="format" />')
+    })
+
+    it('should override the default parse format', function(){
+      changeInput(elm, '11:46:03')
+      expect(elm.val()).toEqual('11:46 am')
+      expect($parentScope.timeval).toEqual('11:46')
+    })
+
+  })
+
+  describe('#parse custom format array', function(){
+    beforeEach(function(){
+      $parentScope.timeval = '23:00'
+      $parentScope.format = ['h:mm', 'h:mm:ssa']
+      compileDirective('<input timepicker ng-model="timeval" parse="format" />')
+    })
+
+    it('should override the default parse function', function(){
+      changeInput(elm, '9:11:44 pm')
+      expect(elm.val()).toEqual('9:11 pm')
+      expect($parentScope.timeval).toEqual('21:11')
     })
 
   })

--- a/timepicker/timepickerDirective.js
+++ b/timepicker/timepickerDirective.js
@@ -45,9 +45,9 @@ var parse = function(val, format, allowTBD) {
   if (allowTBD && (!val || val.toUpperCase() == 'TBD')) return moment('TBD')
 
   var time = val.replace(/[^\d:ap]/gi, '')
-  if (time.match(/24:?0*/)) time = '00:00'
-
   var momentTime = moment(time, format, true)
+  // roll :90 over to 1:30, 24:00 over to 0:00 etc.
+  if (momentTime.parsingFlags().overflow != -1) momentTime = moment(momentTime.toDate())
   return momentTime
 }
 

--- a/timepicker/timepickerDirective.js
+++ b/timepicker/timepickerDirective.js
@@ -47,7 +47,7 @@ var parse = function(val, format, allowTBD) {
   var time = val.replace(/[^\d:ap]/gi, '')
   if (time.match(/24:?0*/)) time = '00:00'
 
-  var momentTime = moment(time, format)
+  var momentTime = moment(time, format, true)
   return momentTime
 }
 
@@ -65,7 +65,7 @@ var defaults = {
   allowtbd: false,
   saveFormat: 'HH:mm',
   print: 'h:mm a',
-  parse: ['h:ma', 'H:m', 'hma', 'Hm']
+  parse: ['h:ma', 'H:m', 'hma', 'Hm', 'ha']
 }
 
 angular.module('sport.ng')

--- a/timepicker/timepickerDirective.js
+++ b/timepicker/timepickerDirective.js
@@ -22,7 +22,7 @@ print attribute:
   The print attribute is optional and converts a time string value to a date
   set to `h:mm a` by default
   must be one of the following:
-  1. moment date format string or array of such strings
+  1. moment date format string
   2. function accepting the following parameters: val (moment object), allowTBD (boolean), and returning a time string to display
 
 parse attribute:

--- a/timepicker/timepickerDirective.js
+++ b/timepicker/timepickerDirective.js
@@ -46,7 +46,7 @@ var parse = function(val, format, allowTBD) {
 
   var time = val.replace(/[^\d:ap]/gi, '')
   var momentTime = moment(time, format, true)
-  // roll :90 over to 1:30, 24:00 over to 0:00 etc.
+  // roll 24:00 over to 0:00
   if (momentTime.parsingFlags().overflow != -1) momentTime = moment(momentTime.toDate())
   return momentTime
 }
@@ -55,6 +55,8 @@ function print(time, format, allowTBD) {
   if (angular.isFunction(format) ) {
     return format(time, allowTBD)
   }
+  // roll 24:00 over to 0:00
+  if (time.parsingFlags().overflow != -1) time = moment(time.toDate())
   if (!time.isValid()){
     return ''
   }
@@ -87,7 +89,6 @@ angular.module('sport.ng')
         if (opts.allowtbd && !('placeholder' in attrs)) element.attr('placeholder', i18ng.t('time_tbd'))
 
         function fromModel(modelValue) {
-          if (modelValue == '24:00') modelValue = '00:00'
           return print(moment(modelValue, opts.saveFormat), opts.print, opts.allowtbd)
         }
 

--- a/timepicker/timepickerDirective.js
+++ b/timepicker/timepickerDirective.js
@@ -45,7 +45,7 @@ var parse = function(val, format, allowTBD) {
   if (allowTBD && (!val || val.toUpperCase() == 'TBD')) return moment('TBD')
 
   var time = val.replace(/[^\d:ap]/gi, '')
-  var momentTime = moment(time, format, true)
+  var momentTime = moment(time, format)
   // roll 24:00 over to 0:00
   if (momentTime.parsingFlags().overflow != -1) momentTime = moment(momentTime.toDate())
   return momentTime


### PR DESCRIPTION
Make timepicker easier to use with other time formats, particularly minute:second formats.
This PR allows the user to input an array of moment strings that will be used to parse user input, instead of an entire function. Generally such a function would be a copy of the timepicker's parse function with different moment strings.
In further support of other time formats, the `24:00` gotcha was fixed in less intrusive way by inserting some rollover code. `24:00` will only get reset to `0:00` when it refers to hours and minutes.
Some tests were added for this new functionality, and the documentation was updated (it hadn't been updated in a while....)